### PR TITLE
Switch the JDK distribution to Temurin

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
 
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
Adopt is no longer updated, it was taken over by Temurin. See <https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/>

There's been some weird behaviour of buildscripts in github actions CI that I could never reproduce locally, this eliminates the outdated JDK as a possible cause.