### PR TITLE
Spotless auto-pr

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,31 @@ jobs:
       run: ./gradlew --info --stacktrace ${{ inputs.workspace }}
 
     - name: Build the mod
+      id: build_mod
       run: ./gradlew --info --stacktrace build
+
+    - name: Attempt to make a PR fixing spotless errors
+      if: ${{ failure() && steps.build_mod.conclusion == 'failure' && github.event_name == 'pull_request' }}
+      run: |
+        ./gradlew --info --stacktrace spotlessApply || exit 1
+        git diff --exit-code && exit 1
+        git config user.name "GitHub GTNH Actions"
+        git config user.email "<>"
+        git switch -c "${FIXED_BRANCH}"
+        git commit -am "spotlessApply"
+        git push --force-with-lease origin "${FIXED_BRANCH}"
+        gh pr create \
+          --head "${FIXED_BRANCH}" \
+          --base "${PR_BRANCH}" \
+          --title "Spotless apply for branch ${PR_BRANCH} for #${{ github.event.pull_request.number }}" \
+          --body "Automatic spotless apply to fix formatting errors, applies to PR #${{ github.event.pull_request.number }}" \
+          2>&1 | tee pr-message.log || true
+        gh pr comment "${PR_BRANCH}" -F pr-message.log || true
+      shell: bash # ensures set -eo pipefail
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_BRANCH: ${{ github.head_ref }}
+        FIXED_BRANCH: ${{ github.head_ref }}-spotless-fixes
 
     - name: Run server for ${{ inputs.timeout }} seconds
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,16 +43,16 @@ jobs:
       run: chmod +x gradlew
 
     - name: Setup the workspace
-      run: ./gradlew ${{ inputs.workspace }}
+      run: ./gradlew --info --stacktrace ${{ inputs.workspace }}
 
     - name: Build the mod
-      run: ./gradlew build
+      run: ./gradlew --info --stacktrace build
 
     - name: Run server for ${{ inputs.timeout }} seconds
       run: |
         mkdir run
         echo "eula=true" > run/eula.txt
-        timeout ${{ inputs.timeout }} ./gradlew runServer 2>&1 | tee -a server.log || true
+        timeout ${{ inputs.timeout }} ./gradlew --info --stacktrace runServer 2>&1 | tee -a server.log || true
 
     - name: Test no errors reported during server run
       run: |

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -40,10 +40,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Setup the workspace
-        run: ./gradlew ${{ inputs.workspace }}
+        run: ./gradlew --info --stacktrace ${{ inputs.workspace }}
 
       - name: Build the mod
-        run: ./gradlew build
+        run: ./gradlew --info --stacktrace build
 
       # Continue on error in the following steps to make sure releases still get made even if one of the methods fails
 
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to Maven
-        run: ./gradlew publish
+        run: ./gradlew --info --stacktrace publish
         continue-on-error: true
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}


### PR DESCRIPTION
When spotless fails in github actions, generate a new branch and PR with the fixes applied for easy fixups of PRs. What happens is: you open pr 123, it fails spotless. Github actions will open a new pr 124 that has a spotlessApply commit on top of 123, 124 can be merged into 123 (not master) to fix it, or be closed if irrelevant.