### PR TITLE
Stop server early if it fully loads successfully

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,7 +82,8 @@ jobs:
       run: |
         mkdir run
         echo "eula=true" > run/eula.txt
-        timeout ${{ inputs.timeout }} ./gradlew --info --stacktrace runServer 2>&1 | tee -a server.log || true
+        echo "stop" > run/stop.txt
+        timeout ${{ inputs.timeout }} ./gradlew --info --stacktrace runServer 2>&1 < run/stop.txt | tee -a server.log || true
 
     - name: Test no errors reported during server run
       if: ${{ !inputs.client-only }}


### PR DESCRIPTION
Tested this locally, the `stop` command only gets processed after all the mods fully load and the spawn chunks are ready. This should save some testing CI time for mods which don't take the full timeout of 90s to load. (Timeout should still be there in case of infinite loops, etc.)