### PR TITLE
Make secrets available

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -10,6 +10,10 @@ on:
         required: false
       MAVEN_PASSWORD:
         required: false
+      CURSEFORGE_TOKEN:
+        required: false
+      MODRINTH_TOKEN:
+        required: false
     inputs:
       workspace:
         description: 'setupCIWorkspace/setupDecompWorkspace'


### PR DESCRIPTION
Makes CURSEFORGE_TOKEN and MODRINTH_TOKEN available to the release workflow