### PR TITLE
Upload built artifacts, spotless bugfixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,13 +50,24 @@ jobs:
     - name: Setup the workspace
       run: ./gradlew --info --stacktrace ${{ inputs.workspace }}
 
-    - name: Build the mod
+    - name: Compile the mod
+      run: ./gradlew --info --stacktrace assemble jar reobfJar
+
+    - name: Attach compilation artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-libs
+        path: build/libs/
+        retention-days: 31
+
+    - name: Run post-build checks
       id: build_mod
       run: ./gradlew --info --stacktrace build
 
     - name: Attempt to make a PR fixing spotless errors
       if: ${{ failure() && steps.build_mod.conclusion == 'failure' && github.event_name == 'pull_request' && !github.event.pull_request.draft }}
       run: |
+        git reset --hard "${PR_BRANCH}"
         ./gradlew --info --stacktrace spotlessApply || exit 1
         git diff --exit-code && exit 1
         git config user.name "GitHub GTNH Actions"


### PR DESCRIPTION
 - Separate compilation from spotless checks (build in gradle depends on assemble and check)
 - Upload a zip of the built jars as a temporary artifact attached to the workflow run (we can use these instead of the jenkins builds, but they're slightly less convenient as they're double-zipped - see <https://github.com/actions/upload-artifact#zipped-artifact-downloads>)
 - Use the PR branch as base when applying spotless fixes and not the hidden PR+merged-head branch, should prevent weird commit logs in the spotless PRs