### PR TITLE
Setup RFG JDK versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,10 +37,12 @@ jobs:
         path: .gtnh-workflows
         fetch-depth: 0
 
-    - name: Set up JDK 8
+    - name: Set up JDK 8 and 17
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: |
+          8
+          17
         distribution: 'temurin'
         cache: gradle
 

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -33,10 +33,12 @@ jobs:
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Set up JDK 8
+      - name: Set up JDK 8 and 17
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: |
+            8
+            17
           distribution: 'temurin'
           cache: gradle
 


### PR DESCRIPTION
Once most/all repos are updated to RFG, this will enable using Jabel and make gradle a bit faster. It's incompatible with the old buildscript unfortunately.