### PR TITLE
Switch GHA JDK to Azul to avoid Gradle downloading it from upstream

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
         java-version: |
           8
           17
-        distribution: 'temurin'
+        distribution: 'zulu'
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: |
             8
             17
-          distribution: 'temurin'
+          distribution: 'zulu'
           cache: gradle
 
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
Merge after <https://github.com/GTNewHorizons/ExampleMod1.7.10/pull/146>.
Azul is the vendor, Zulu is the JDK name for reference.