### PR TITLE
Validate the gradlew checksums before running any build commands

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,9 @@ jobs:
         path: .gtnh-workflows
         fetch-depth: 0
 
+    - name: Validate gradle wrapper checksum
+      uses: gradle/wrapper-validation-action@v1
+
     - name: Set up JDK 8 and 17
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 32
 
+      - name: Validate gradle wrapper checksum
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 


### PR DESCRIPTION
To prevent malicious gradlew jars from sneaking into our repositories via PRs.