### PR TITLE
Set a consistent seed when starting the CI server run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,6 +99,8 @@ jobs:
       run: |
         mkdir -p run
         echo "eula=true" > run/eula.txt
+        # Set a constant seed with a village at spawn
+        echo "level-seed=-6202107849386030209\nonline-mode=true\n" > run/server.properties
         echo "stop" > run/stop.txt
         timeout ${{ inputs.timeout }} ./gradlew --build-cache --info --stacktrace runServer 2>&1 < run/stop.txt | tee -a server.log || true
 


### PR DESCRIPTION
Make sure every CI run starts with the same seed to make tests reproducible and easier to debug locally