### PR TITLE
Label reviews

### DIFF
--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label requires reviews
-        uses: BlueWeabo/label-requires-reviews-action@master
+        uses: GTNewHorizons/label-requires-reviews-action@master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -18,14 +18,18 @@ jobs:
   require-reviewers:
     # Optional: skip check if no relevant label is present
     # This needs to be kept in sync with the labels being checked
+    # These don't need to hold the entire label name and aren't case sensitive
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Affects Balance') || contains(github.event.pull_request.labels.*.name, 'ongoing freeze') }}
     runs-on: ubuntu-latest
     steps:
       - name: Label requires reviews
-        uses: travelperk/label-requires-reviews-action@1.3.0
+        uses: BlueWeabo/label-requires-reviews-action@master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # define which PR labels require how many aprroving reviewers
+          # Case sensitive and needs the full label name.
           rules_yaml: |-
             Affects Balance: 3 
             ongoing freeze - don't merge: 99

--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -1,0 +1,32 @@
+# This workflow will set a number or reviewers depending on the labels
+name: Label Reviews
+# Trigger the workflow on pull requests
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+jobs:
+  require-reviewers:
+    # Optional: skip check if no relevant label is present
+    # This needs to be kept in sync with the labels being checked
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Affects Balance') || contains(github.event.pull_request.labels.*.name, 'ongoing freeze') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label requires reviews
+        uses: travelperk/label-requires-reviews-action@1.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
+          # define which PR labels require how many aprroving reviewers
+          rules_yaml: |-
+            Affects Balance: 3 
+            ongoing freeze - don't merge: 99
+            


### PR DESCRIPTION
Add a Github action to be able to require a custom amount of reviews before allowing a PR to be merged. It is currently impossible to make it require a specific member of a team to have a review in it, but should still be helpful for some labels.