### PR TITLE
Add ability to skip GitHub publication

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -92,4 +92,4 @@ jobs:
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
-        if: ${{ env.MAVEN_USER != '' }}
+        if: ${{ !contains(github.event.head_commit.message, '[snapshot]') }}

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !contains(github.event.head_commit.message, '[no github]') }}
+        if: ${{ !contains(github.event.head_commit.message, '[snapshot]') }}
 
       - name: Publish to Maven
         run: ./gradlew --build-cache --info --stacktrace build publish

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -78,12 +78,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !contains(github.event.head_commit.message, '[no github]') }}
 
-      - name: Publish to Maven, Modrinth and CurseForge
+      - name: Publish to Maven
         run: ./gradlew --build-cache --info --stacktrace build publish
         continue-on-error: true
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        if: ${{ env.MAVEN_USER != '' }}
+
+      - name: Publish to Modrinth and CurseForge
+        run: ./gradlew --build-cache --info --stacktrace build publish
+        continue-on-error: true
+        env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
         if: ${{ env.MAVEN_USER != '' }}

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -76,6 +76,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ !contains(github.event.head_commit.message, '[no github]') }}
 
       - name: Publish to Maven, Modrinth and CurseForge
         run: ./gradlew --build-cache --info --stacktrace build publish


### PR DESCRIPTION
Pushing commit with `[snapshot]` in the commit name makes CI skip GitHub publication, while still pushing to maven. This is useful for not publishing release with breaking changes so that DAXXL won't pick it up, while still publishing to maven for use in other mods.
I also tried to make it work with release note, but couldn't find the right way.
Tested here: https://github.com/miozune/GT5-Unofficial/actions/runs/6727961771/job/18286549465