### PR TITLE
Prevent merging of PRs with `-pre` dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,3 +109,7 @@ jobs:
       run: |
         chmod +x .gtnh-workflows/scripts/test_no_error_reports
         .gtnh-workflows/scripts/test_no_error_reports
+
+    - name: Test no prerelease dependencies used
+      run: |
+        ! grep -F -- "-pre" dependencies.gradle*


### PR DESCRIPTION
A simple regex search for `-pre` in `dependencies.gradle[.kts]` to fail PR checks when -pre dependencies are used.