### PR TITLE
Don't run tests on release

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' ${{ inputs.workspace }}
 
       - name: Build the mod
-        run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' build -x test
+        run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' assemble
 
       # Continue on error in the following steps to make sure releases still get made even if one of the methods fails
 

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' ${{ inputs.workspace }}
 
       - name: Build the mod
-        run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' build
+        run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' build -x test
 
       # Continue on error in the following steps to make sure releases still get made even if one of the methods fails
 


### PR DESCRIPTION
 - They should already have been run, alternatively we'd need to enable xvfb as we do for the build step