### PR TITLE
Make artifact retention set to 90 days instead of 31 days

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         name: ${{ github.repository_id }}-build-libs
         path: build/libs/
-        retention-days: 31
+        retention-days: 90
 
     - name: Run post-build checks
       id: build_mod


### PR DESCRIPTION
By default, public repos have the ability to have artifacts last for 90 days instead of 31. May as well have the retention time set to the maximum, right?