### PR TITLE
Update gradle wrapper validation to v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
         fetch-depth: 0
 
     - name: Validate gradle wrapper checksum
-      uses: gradle/wrapper-validation-action@v2
+      uses: gradle/actions/wrapper-validation@v3
 
     - name: Set up JDK versions
       uses: actions/setup-java@v4

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 32
 
       - name: Validate gradle wrapper checksum
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up JDK versions
         uses: actions/setup-java@v4


### PR DESCRIPTION
Moves to the new action as the old location is deprecated.

Also hopefully fixes issues like these random CI failures: https://github.com/GTNewHorizons/ServerUtilities/actions/runs/12455108478/job/34767123728