### PR TITLE
Update gradle setup action and GHA runner OS version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Install Ubuntu dependencies
       run: |
@@ -41,9 +41,6 @@ jobs:
         path: .gtnh-workflows
         fetch-depth: 0
 
-    - name: Validate gradle wrapper checksum
-      uses: gradle/actions/wrapper-validation@v3
-
     - name: Set up JDK versions
       uses: actions/setup-java@v4
       with:
@@ -52,7 +49,14 @@ jobs:
           21
           17
         distribution: 'zulu'
-        cache: gradle
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        build-scan-publish: true
+        build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+        build-scan-terms-of-use-agree: "yes"
+        validate-wrappers: true
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/label-reviews.yml
+++ b/.github/workflows/label-reviews.yml
@@ -10,7 +10,7 @@ jobs:
     # This needs to be kept in sync with the labels being checked
     # These don't need to hold the entire label name and aren't case sensitive
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Affects Balance') || contains(github.event.pull_request.labels.*.name, 'ongoing freeze') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Label requires reviews
         uses: GTNewHorizons/label-requires-reviews-action@master
@@ -21,6 +21,5 @@ jobs:
           # define which PR labels require how many aprroving reviewers
           # Case sensitive and needs the full label name.
           rules_yaml: |-
-            Affects Balance: 3 
+            Affects Balance: 3
             ongoing freeze - don't merge: 99
-            

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       VERSION: ${{ github.ref_name }}
       RELEASE_VERSION: ${{ github.ref_name }}
@@ -35,9 +35,6 @@ jobs:
         with:
           fetch-depth: 32
 
-      - name: Validate gradle wrapper checksum
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK versions
         uses: actions/setup-java@v4
         with:
@@ -46,7 +43,14 @@ jobs:
             21
             17
           distribution: 'zulu'
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+          validate-wrappers: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
- Update GHA runners to Ubuntu 24.04, pinning the version so it doesn't surprise-update
- Replace the gradle wrapper validation action with setup-gradle that does validation and better caching than the old setup
- Enable build scans for our builds, this is useful to get a HTML report of what went wrong and/or how long builds took
- Clean up whitespace in the labels workflow

I'll open a test PR in gt5u in a sec to test that this works fine