### PR TITLE
Separate Modrinth/CF task

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -96,10 +96,16 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         if: ${{ env.MAVEN_USER != '' }}
 
-      - name: Publish to Modrinth and CurseForge
+      - name: Publish to Modrinth
         run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' assemble publish -x test
         continue-on-error: true
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        if: ${{ env.SNAPSHOT != 'true' }}
+
+      - name: Publish to Curseforge
+        run: ./gradlew --build-cache --info --stacktrace -PmavenPublishUrl='${{ env.MAVEN_PUBLISHING_URL }}' assemble publish -x test
+        continue-on-error: true
+        env:
           CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
         if: ${{ env.SNAPSHOT != 'true' }}


### PR DESCRIPTION
Modrinth seems to be timing out for a response on large files (despite the upload actually going through) which seems to be blocking the CF upload - so split them into separate tasks