### PR TITLE
Add upstream commentor script

### DIFF
--- a/.github/workflows/upstream_commentor.yml
+++ b/.github/workflows/upstream_commentor.yml
@@ -1,0 +1,48 @@
+name: Mention upstream repo for new pull requests
+
+on:
+  workflow_call:
+    inputs:
+      upstream:
+        description: 'URL to the upstream repository'
+        required: true
+        type: string
+      auto_close:
+        description: 'Whether to close the PR after commenting'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream: ${{ inputs.upstream }}
+          auto_close: ${{ inputs.auto_close }}
+          script: |
+            const upstream = core.getInput('upstream');
+            const commentBody = `Thanks for the PR!
+
+            PRs to this repo should be opened on the upstream repo [here](${upstream}) instead of the GTNH fork. This can be ignored if there is a good reason to PR to specifically the fork instead.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: commentBody
+            });
+
+            const auto_close = core.getBooleanInput('auto_close');
+            if (auto_close) {
+              github.rest.issues.update({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed'
+              });
+            }

--- a/.github/workflows/upstream_commentor.yml
+++ b/.github/workflows/upstream_commentor.yml
@@ -28,7 +28,7 @@ jobs:
             const upstream = core.getInput('upstream');
             const commentBody = `Thanks for the PR!
 
-            PRs to this repo should be opened on the upstream repo [here](${upstream}) instead of the GTNH fork. This can be ignored if there is a good reason to PR to specifically the fork instead.`;
+            PRs to this repo should be closed and reopened on the [upstream repo](${upstream}) instead of the GTNH fork. This can be ignored if there is a good reason to PR to specifically the fork instead.`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Adds a new script that can be used on repos to automatically comment on any opened PR to mention an upstream repo. Can also optionally close the PR automatically.

Example script in a repository:
```yml
name: Mention upstream repo for new pull requests

on:
  pull_request:
    types: [opened]

jobs:
  comment:
    uses: GTNewHorizons/GTNH-Actions-Workflows/.github/workflows/upstream_commentor_ref.yml@master
    secrets: inherit
    with:
      # URL to the upstream, required
      upstream: 'https://github.com/Roadhog360/Et-Futurum-Requiem'
      # Whether to close the PR automatically. Optional, default false
      auto_close: true
```

Test of the comment: https://github.com/serenibyss/TestCI/pull/8
Test of the auto-closer: https://github.com/serenibyss/TestCI/pull/9