### PR TITLE
Add a sanity check to build-and-test workflow to prevent overzealous asset file optimizations

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,3 +131,21 @@ jobs:
     - name: Test no prerelease dependencies used
       run: |
         ! grep -P -- "-pre(?!shadow)" dependencies.gradle*
+
+    # See https://github.com/GTNewHorizons/GT5-Unofficial/pull/4880
+    - name: Make sure asset files are not overoptimized
+      run: |
+        echo "Checking for grayscale asset files which are not supported by the java8 image loader"
+        fail=0
+        set -o pipefail
+        while IFS= read -r -d $'\n' file; do
+          if $(file --brief -- "$file" | grep -q grayscale); then
+            printf "found grayscale image '%s'\n" "$file"
+            fail=1
+          fi
+        done < <(gh pr diff --name-only "${PR_NUMBER}" | grep 'src/main/resources/.*\.png$')
+
+        exit $fail
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT5-Unofficial/pull/4880

Demo here: https://github.com/GTNewHorizons/GT5-Unofficial/actions/runs/17778544951/job/50532220465#step:17:36