### PR TITLE
fix(optimize-images): fix git implementation of pr diff

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -25,8 +25,9 @@ jobs:
             echo 'png_files<<EOF'
             if [ "${{ github.event_name }}" = pull_request ] &&
                [ "${{ !github.event.pull_request.draft }}" = true ]; then
+              git fetch origin "$GITHUB_BASE_REF" &&
               git fetch origin "$GITHUB_BASE_REF" "refs/pull/$PR_NUMBER/head:pr-$PR_NUMBER" &&
-              git diff --name-only -l10000 "origin/$GITHUB_BASE_REF" "pr-$PR_NUMBER" -- '*.png'
+              git diff --name-only --diff-filter=AM --no-renames "origin/$GITHUB_BASE_REF" "pr-$PR_NUMBER" -- '*.png'
             else
               find "$GITHUB_WORKSPACE" -type f -name "*.png" ! -path "$GITHUB_WORKSPACE/.git/*" -print 2>/dev/null
             fi


### PR DESCRIPTION
- GitHub does not fetch the `$GITHUB_BASE_REF` in a PR, but only the PR. So it needs to fetch the `$GITHUB_BASE_REF` to be able to diff with the PR.
- Modify the diff filter to only account for **M**odified or **A**dded files, excluding renames, it also removes the need to extend the rename list limit.