### PR TITLE
fix logical flaw in the png optimisation script

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -51,7 +51,6 @@ jobs:
 
           if [ -n "$failed_files" ]; then
             printf 'failed_files<<EOF\n%sEOF\n' "$failed_files" >> "$GITHUB_OUTPUT"
-            exit 1
           fi
 
       - name: Print files that failed to compress


### PR DESCRIPTION
In the script i previously added an `exit 1` in the script if there was files to compress, which was supposed to indicate that there was files to compress. However, it does not make sense to do so because the next tasks can't happen, and it marks the whole workflow as failed anyways if it runs into improperly compressed files. That logical flaw also crashes before the task listing the the improperly compressed files can run, so it just looks like a mystical error.