### PR TITLE
Cancel previous runs for a workflow if another is started in the same pr

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -3,6 +3,10 @@ name: Check for image compression
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compress:
     name: Compress and make a PR if needed

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -21,6 +21,10 @@ on:
         default: "setupCIWorkspace"
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
`${{ github.event.pull_request.number || github.ref }}` -  when the trigger is not a PR but a push, it will use the branch or tag name to generate the concurrency group else it uses the pr number

Been annoying the hell out of me if you do several small pushes back to back

Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
