### PR TITLE
build-and-test: individual jar uploads and spotless PR toggle

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Attach gradle reports
       if: failure() && steps.build_mod.conclusion == 'failure'
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       continue-on-error: true
       with:
         name: ${{ github.repository_id }}-reports

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,10 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
+
+    outputs:
+      jar_matrix: ${{ steps.expose-jars.outputs.matrix }}
+
     steps:
     - name: Install Ubuntu dependencies
       run: |
@@ -83,29 +87,6 @@ jobs:
 
     - name: Compile the mod
       run: ./gradlew --build-cache --info --stacktrace assemble
-
-    - name: Attach user artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ github.repository_id }}-build-libs
-        path: |
-          build/libs/
-          !build/libs/*-api.jar
-          !build/libs/*-dev.jar
-          !build/libs/*-dev-preshadow.jar
-          !build/libs/*-sources.jar
-        retention-days: 90
-
-    - name: Attach dev artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ github.repository_id }}-build-dev-libs
-        path: |
-          build/libs/*-api.jar
-          build/libs/*-dev.jar
-          build/libs/*-dev-preshadow.jar
-          build/libs/*-sources.jar
-        retention-days: 90
 
     - name: Run post-build checks
       id: build_mod
@@ -189,3 +170,27 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}
+
+    - name: Upload Legacy ZIP Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ github.repository_id }}-build-libs
+        path: build/libs/
+        retention-days: 90
+
+    - name: Scan build folder for dynamic JARs
+      id: expose-jars
+      run: |
+        shopt -s nullglob
+        JAR_JSON=$(jq -n -c '$ARGS.positional' --args build/libs/*.jar)
+        echo "matrix=$JAR_JSON" >> "$GITHUB_OUTPUT"
+
+  run-unzipped-uploads:
+    needs: build-and-test
+    strategy:
+      fail-fast: false
+      matrix:
+        jar: ${{ fromJson(needs.build-and-test.outputs.jar_matrix) }}
+    uses: ./.github/workflows/upload-unzipped-jar.yml
+    with:
+      jar_path: ${{ matrix.jar }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,7 +99,7 @@ jobs:
       with:
         name: ${{ github.repository_id }}-reports
         path: build/reports/
-        retention-days: 31
+        retention-days: 90
 
     - name: Attempt to make a PR fixing spotless errors
       if: >-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      disable-spotless-pr:
+        description: 'Do not run spotless PR task'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -103,7 +108,7 @@ jobs:
 
     - name: Attempt to make a PR fixing spotless errors
       if: >-
-        ${{ !github.event.inputs.disable-spotless &&
+        ${{ !inputs.disable-spotless-pr &&
         failure() && steps.build_mod.conclusion == 'failure' &&
         github.event_name == 'pull_request' &&
         !github.event.pull_request.draft &&

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,11 +84,27 @@ jobs:
     - name: Compile the mod
       run: ./gradlew --build-cache --info --stacktrace assemble
 
-    - name: Attach compilation artifacts
-      uses: actions/upload-artifact@v5
+    - name: Attach user artifacts
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.repository_id }}-build-libs
-        path: build/libs/
+        path: |
+          build/libs/
+          !build/libs/*-api.jar
+          !build/libs/*-dev.jar
+          !build/libs/*-dev-preshadow.jar
+          !build/libs/*-sources.jar
+        retention-days: 90
+
+    - name: Attach dev artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.repository_id }}-build-dev-libs
+        path: |
+          build/libs/*-api.jar
+          build/libs/*-dev.jar
+          build/libs/*-dev-preshadow.jar
+          build/libs/*-sources.jar
         retention-days: 90
 
     - name: Run post-build checks
@@ -106,10 +122,11 @@ jobs:
 
     - name: Attempt to make a PR fixing spotless errors
       if: >-
-        ${{ failure() && steps.build_mod.conclusion == 'failure'
-          && github.event_name == 'pull_request'
-          && !github.event.pull_request.draft
-          && github.event.pull_request.head.repo.full_name == github.repository }}
+        ${{ !github.event.inputs.disable-spotless &&
+        failure() && steps.build_mod.conclusion == 'failure' &&
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository }}
       run: |
         git reset --hard
         git checkout "${PR_BRANCH}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,26 +171,26 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}
 
-    - name: Upload Legacy ZIP Artifact
+    - name: Attach compilation artifacts as ZIP
       uses: actions/upload-artifact@v7
       with:
         name: ${{ github.repository_id }}-build-libs
         path: build/libs/
         retention-days: 90
 
-    - name: Scan build folder for dynamic JARs
+    - name: Store the name of each built file
       id: expose-jars
       run: |
         shopt -s nullglob
         JAR_JSON=$(jq -n -c '$ARGS.positional' --args build/libs/*.jar)
         echo "matrix=$JAR_JSON" >> "$GITHUB_OUTPUT"
 
-  run-unzipped-uploads:
+  run-individual-uploads:
     needs: build-and-test
     strategy:
       fail-fast: false
       matrix:
         jar: ${{ fromJson(needs.build-and-test.outputs.jar_matrix) }}
-    uses: ./.github/workflows/upload-unzipped-jar.yml
+    uses: ./.github/workflows/upload-individual-jar.yml
     with:
       jar_path: ${{ matrix.jar }}

--- a/.github/workflows/upload-individual-jar.yml
+++ b/.github/workflows/upload-individual-jar.yml
@@ -1,4 +1,4 @@
-name: Upload Unzipped Jar
+name: Upload individual JAR
 
 on:
   workflow_call:
@@ -8,19 +8,19 @@ on:
         type: string
 
 jobs:
-  upload:
+  upload-individual-jar:
     runs-on: ubuntu-24.04
     steps:
     # In order to run this for all jars, we have to call it individually for each jar, on a separate job.
     # Because dynamically running this workflow file requires a unique job run, we can't just grab the jars directly because they're already gone by then.
     # We have to do this because unzipped upload can only be ran on one file (arbitrary restrictions 💢)
-      - name: Retrieve Compiled Jars
+      - name: Extract archive to retrieve artifact
         uses: actions/download-artifact@v8
         with:
           name: ${{ github.repository_id }}-build-libs
           path: build/libs
 
-      - name: Upload Unzipped Jar
+      - name: Upload individual compilation artifact
         uses: actions/upload-artifact@v7
         with:
           path: ${{ inputs.jar_path }}

--- a/.github/workflows/upload-individual-jar.yml
+++ b/.github/workflows/upload-individual-jar.yml
@@ -24,4 +24,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: ${{ inputs.jar_path }}
+          retention-days: 90
           archive: false

--- a/.github/workflows/upload-unzipped-jar.yml
+++ b/.github/workflows/upload-unzipped-jar.yml
@@ -1,0 +1,24 @@
+name: Upload Unzipped Jar
+
+on:
+  workflow_call:
+    inputs:
+      jar_path:
+        required: true
+        type: string
+
+jobs:
+  upload:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Retrieve Compiled Jars
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.repository_id }}-build-libs
+          path: build/libs
+
+      - name: Upload Unzipped Jar
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ inputs.jar_path }}
+          archive: false

--- a/.github/workflows/upload-unzipped-jar.yml
+++ b/.github/workflows/upload-unzipped-jar.yml
@@ -11,8 +11,11 @@ jobs:
   upload:
     runs-on: ubuntu-24.04
     steps:
+    # In order to run this for all jars, we have to call it individually for each jar, on a separate job.
+    # Because dynamically running this workflow file requires a unique job run, we can't just grab the jars directly because they're already gone by then.
+    # We have to do this because unzipped upload can only be ran on one file (arbitrary restrictions 💢)
       - name: Retrieve Compiled Jars
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.repository_id }}-build-libs
           path: build/libs


### PR DESCRIPTION
- Added input to disable spotless PRs.
- Changed failure report retention time to 90
- Zip upload moved to near the end of the task list. The original zip will be provided for legacy reasons, so existing nightly.link references continue to work.
- Moved uploading logic to the end, so that way it's after the server and client runs, that way if the test client/server run fails, artifacts are not uploaded.
- Jar artifacts are individually uploaded alongside the original zip file, allowing players to download the individual jar directly, without having to download the zip. This will make it easier for users to find the correct jar, and is more immediately obvious as they don't have to download the whole zip file to find what they want.
- Unzipped uploads have to be individual, so we work around this by collecting a list of the jars that were applied to the build folder. We then pass that to a new job that loops through and uploads the jars.
  - A new yml workflow is created as rolling this into the main build-and-test script needs scripting that has no syntax highlighting or hints and thus may be difficult for maintainers to gauge what it does.
  - **DISCLAIMER:** This specific behavior was written by Google Gemini. Despite me hating working with yaml files and finding their picky spacing-based syntax to be a pain in the ass, I am still able to get a general idea of what it did. Its changes seem very straightforward so I was able to be confident these changes are stable. Additionally I have tested the script on my end. [A test workflow is available here](https://github.com/Roadhog360/Et-Futurum-Requiem/actions/runs/26216954329).