### PR TITLE
Base OI PRs on Source Branch

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Install optipng
         run: |


### PR DESCRIPTION
Prevents generated OI PRs from accidentally including unrelated base branch code changes when the source branch is behind its target branch.

Tested

Ex of issue:
<img width="1337" height="933" alt="image" src="https://github.com/user-attachments/assets/13a653da-e775-4a9f-9ec5-2e0e32c1170b" />
