### PR TITLE
Only run Horizon-QA result checks after runServer executes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -154,6 +154,7 @@ jobs:
         FIXED_BRANCH: ${{ github.head_ref }}-spotless-fixes
 
     - name: Run server for up to ${{ inputs.timeout }} seconds
+      id: run_server
       if: ${{ !inputs.client-only }}
       shell: bash
       env:
@@ -198,7 +199,7 @@ jobs:
         timeout ${{ inputs.timeout }} ./gradlew "${gradle_args[@]}" 2>&1 < "${server_stdin}" | tee -a server.log || true
 
     - name: Upload Horizon-QA reports
-      if: ${{ always() && !inputs.client-only && inputs.horizonqa }}
+      if: ${{ always() && !inputs.client-only && inputs.horizonqa && steps.run_server.conclusion != 'skipped' }}
       uses: actions/upload-artifact@v7
       continue-on-error: true
       with:
@@ -207,7 +208,7 @@ jobs:
         retention-days: 90
 
     - name: Summarize Horizon-QA result
-      if: ${{ always() && !inputs.client-only && inputs.horizonqa }}
+      if: ${{ always() && !inputs.client-only && inputs.horizonqa && steps.run_server.conclusion != 'skipped' }}
       shell: bash
       continue-on-error: true
       run: |
@@ -215,7 +216,7 @@ jobs:
         .gtnh-workflows/scripts/summarize_horizonqa_result
 
     - name: Test Horizon-QA result
-      if: ${{ always() && !inputs.client-only && inputs.horizonqa }}
+      if: ${{ always() && !inputs.client-only && inputs.horizonqa && steps.run_server.conclusion != 'skipped' }}
       shell: bash
       run: |
         chmod +x .gtnh-workflows/scripts/test_horizonqa_result


### PR DESCRIPTION
### What changed

This gives the `Run server for up to ... seconds` step an id and gates the Horizon-QA follow-up steps on that step having actually executed.

### Why

The Horizon-QA upload/summary/test steps use `always()` so they can still run after `runServer` completes and produces failing or missing QA results.

However, if an earlier step fails before `runServer`, GitHub Actions skips the server step. In that case Horizon-QA never had a chance to run, but the result-checking steps still execute and can fail due to missing output. That creates a misleading secondary failure.

With this change, Horizon-QA post-processing still runs when `runServer` executes, but it is skipped when `runServer` itself was skipped.

### Behavior

- If `runServer` runs and Horizon-QA does not produce valid results, the Horizon-QA result test can still fail.
- If `runServer` is skipped because an earlier build/check step failed, Horizon-QA follow-up steps are skipped too.