### PR TITLE
Switch out pr url lookup method with repos/repo/pulls + filter

### DIFF
--- a/.github/workflows/latest-daily-integration-test.yml
+++ b/.github/workflows/latest-daily-integration-test.yml
@@ -34,10 +34,14 @@ jobs:
         id: lookup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }} # Not inlined below to prevent injection from branch names
         run: |
-          PR_URL=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-            --jq "[.[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\" and .state == \"open\")] | first | .html_url // empty")
+          PR_URL=$(gh api --method GET \
+            "repos/${{ github.repository }}/pulls" \
+            -f state=open \
+            -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${HEAD_BRANCH}" \
+            -f base="${{ github.event.repository.default_branch }}" \
+            --jq "([.[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\")] | first | .html_url) // (first | .html_url) // empty")
 
           if [ -z "$PR_URL" ]; then
             echo "Failed to find a PR url"

--- a/.github/workflows/trigger-rebuild-with-deps.yml
+++ b/.github/workflows/trigger-rebuild-with-deps.yml
@@ -23,10 +23,14 @@ jobs:
         id: lookup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }} # Not inlined below to prevent injection from branch names
         run: |
-          PR_URL=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-            --jq "[.[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\" and .state == \"open\")] | first | .html_url // empty")
+          PR_URL=$(gh api --method GET \
+            "repos/${{ github.repository }}/pulls" \
+            -f state=open \
+            -f head="${{ github.event.workflow_run.head_repository.owner.login }}:${HEAD_BRANCH}" \
+            -f base="${{ github.event.repository.default_branch }}" \
+            --jq "([.[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\")] | first | .html_url) // (first | .html_url) // empty")
 
           if [ -z "$PR_URL" ]; then
             echo "Failed to find a PR url"


### PR DESCRIPTION
## Summary
This PR fixes PRs lookups in the new workflows that fail when the PR is from a fork.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
